### PR TITLE
Tidy up shell scripting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# screen-workdir.sh
+Utility to create session with the current folder name on GNU Screen
+
+### Install
+
+```sh
+$ curl https://raw.githubusercontent.com/gutierri/screen-workdir.sh/master/screen-workdir.sh ~/.local/bin/screen-workdir.sh
+
+$ echo "source ~/.local/bin/screen-workdir.sh >> ~/.bashrc"
+```
+
+### Usage
+
+Now there is a -w parameter <kbd>screen -w</kbd>
+
+```sh
+$ cd ~/Projects/myproject
+
+$ screen -w
+```
+---
+License (GPLv3) Copyright (C) 2017 Gutierri Barboza me@gutierri.me

--- a/screen-workdir.sh
+++ b/screen-workdir.sh
@@ -3,23 +3,22 @@
 
 if [ -x "$(command -v /usr/bin/screen)" ];
 then
-	SCREEN=/usr/bin/screen
+        SCREEN=/usr/bin/screen
 else
-	SCREEN=/usr/local/bin/screen
+        SCREEN=/usr/local/bin/screen
 fi
 
 function screen(){
-	if echo $@ | grep -q "^\-w"; then
-		shift
-		if [ -z "$STY" ]; then
-			local local_path=$(pwd|rev|cut -d/ -f1|rev)
-			bash -c "$SCREEN -S $local_path"
-		else
-			echo "Session it's running... Close try again."
-		fi
-	else
-		bash -c "$SCREEN $@"
-	fi
+        if [[ "$@" =~ "-w" ]]; then
+                shift
+                if [ -z "$STY" ]; then
+                        $SCREEN -S ${PWD##*/}
+                else
+                        echo "Session it's running... Close try again."
+                fi
+        else
+                $SCREEN $@
+        fi
 }
 
 export screen


### PR DESCRIPTION
* Use built in regex for testing if -w is present
* Use PWD variable, use built in string function to get directory name 
* Remove extra subshells `bash -c`
* 8 spaces instead of 7